### PR TITLE
Fix for 'all connections are in use' when calling read.markup.RCC() on multiple files.

### DIFF
--- a/R/read.markup.RCC.R
+++ b/R/read.markup.RCC.R
@@ -51,17 +51,21 @@ read.markup.RCC <- function(rcc.path = ".", rcc.pattern = "*.RCC|*.rcc", exclude
 		# convert data into table for all data structures
 		header.con <- textConnection(as.character(header.info$text));
 		header.data <- read.csv(header.con, header = FALSE, stringsAsFactors = FALSE);
+		close(header.con)
 
 		sample.con <- textConnection(as.character(sample.info$text));
 		sample.data <- read.csv(sample.con, header = FALSE, stringsAsFactors = FALSE);
 		sample.data[which(sample.data[, 1] == "ID"), 1] <- "sample.id";
+		close(sample.con)
 
 		lane.con <- textConnection(as.character(lane.info$text));
 		lane.data <- read.csv(lane.con, header = FALSE, stringsAsFactors = FALSE);
 		lane.data[which(lane.data[, 1] == "ID"), 1] <- "lane.id";
+		close(lane.con)
 
 		code.con <- textConnection(as.character(code.info$text));
 		code.data <- read.csv(code.con, header = TRUE, stringsAsFactors = FALSE);
+		close(code.con)
 
 		# combine metadata
 		rcc.header <- do.call(rbind, list(header.data, sample.data, lane.data));


### PR DESCRIPTION
_Package Version: NanoStringNorm 1.2.0
R Version: 3.3.2
OS: Windows 10 x64_

When loading a series of 144 raw Nanostring RCC files using `NanoStringNorm::read.markup.RCC()`, processing of the 32nd file fails with the error:

```
 Error in textConnection(as.character(sample.info$text)) :
  all connections are in use
```

...when creating the `sample.con` textConnection (https://github.com/cran/NanoStringNorm/blob/1.2.0/R/read.markup.RCC.R#L55)

`help("connections", package="base")` states that the maximum number of allocated connections is 128 (with 3 reserved for `stdin, stdout, stderr`) and I can see that `read.markup.RCC()` is opening textConnections but not closing them and hitting the hard limit of 125 usable connections.

As each call to `read.markup.RCC()` opens 4 connections, all 125 available will be allocated by the time sample.con is created on the 32nd iteration.

Simply closing the connection once the data has been read from the file resolves this problem.